### PR TITLE
move IFDRational handling to normalize function

### DIFF
--- a/py_image_dedup/persistence/__init__.py
+++ b/py_image_dedup/persistence/__init__.py
@@ -1,5 +1,7 @@
 import os
 
+from PIL import TiffImagePlugin
+
 from py_image_dedup.persistence.metadata_key import MetadataKey
 
 
@@ -83,6 +85,11 @@ class ImageSignatureStore:
             normalized_value = v
             if isinstance(v, bytes) or isinstance(v, tuple):
                 normalized_value = str(v)
+            elif isinstance(v, TiffImagePlugin.IFDRational):
+                if v._denominator != 0:
+                    normalized_value = v._numerator / v._denominator
+                else:
+                    normalized_value = float(v._numerator)
 
             result[k] = normalized_value
 

--- a/py_image_dedup/util/image.py
+++ b/py_image_dedup/util/image.py
@@ -1,5 +1,5 @@
 import PIL.ExifTags
-from PIL import Image, TiffImagePlugin
+from PIL import Image
 
 
 def get_exif_data(image_file_path: str) -> {}:
@@ -20,11 +20,6 @@ def get_exif_data(image_file_path: str) -> {}:
         for k, v in exif_data.items():
             if k in PIL.ExifTags.TAGS:
                 tag_name = PIL.ExifTags.TAGS[k]
-                if isinstance(v, TiffImagePlugin.IFDRational):
-                    if v._denominator != 0:
-                        v = v._numerator / v._denominator
-                    else:
-                        v = float(v._numerator)
                 result[tag_name] = v
     except Exception as e:
         pass


### PR DESCRIPTION
Just realized that some dicts in EXIF data also can contain IFDRational (in my case the `GPSInfo`).

This moves the IFD handling out to your nice `_normalize_meta_data_for_db` function.