### PR TITLE
Feature/#80 custom prioritization

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,21 @@ is advised to get the best performance.
 
 Since we might already have a previous version of this file in the database 
 before analysing a given file the file modification time is compared to the
-given one. If the database content seems to be still correct the signature 
+given one. If the database content seems to be still correct the signature
 for this file will **not** be recalculated. Because of this, subsequent
 runs will be much faster. There still has to happen some file access though,
 so it is probably limited by that.
- 
+
 ### Phase 4 - Finding duplicates
 
-Every file is now processed again - but only by means of querying the 
+Every file is now processed again - but only by means of querying the
 database backend for similar images (within the given `max_dist`).
 If there are images found that match the similarity criteria they are considered
-duplicate candidates. All candidates are then ordered by the following
-criteria (in this exact order):
+duplicate candidates. All candidates are then ordered according to the `prioritization_rules`,
+which you can specify yourself in the configuration, see [Configuration](#Configuration).
+
+If you do not specify `prioritization_rules` yourself, the following order will
+be used:
 
 1. pixel count (more is better)
 1. EXIF data (more exif data is better)
@@ -90,10 +93,10 @@ pip3 install py-image-dedup
 
 **py-image-dedup** uses [container-app-conf](https://github.com/markusressel/container-app-conf)
 to provide configuration via a YAML file as well as ENV variables which
-generates a reference config on startup. Have a look at the 
-[documentation about it](https://github.com/markusressel/container-app-conf#generate-reference-config)
+generates a reference config on startup. Have a look at the
+[documentation about it](https://github.com/markusressel/container-app-conf#generate-reference-config).
 
-See [py_image_dedup_reference.yaml](/py_image_dedup_reference.yaml) 
+See [py_image_dedup_reference.yaml](/py_image_dedup_reference.yaml)
 for an example in this repo.
 
 ## Setup elasticsearch backend

--- a/py_image_dedup/config.py
+++ b/py_image_dedup/config.py
@@ -1,3 +1,4 @@
+import os
 from datetime import timedelta
 
 from container_app_conf import ConfigBase
@@ -43,6 +44,7 @@ NODE_THREADS = "threads"
 
 NODE_DEDUPLICATION = "deduplication"
 
+NODE_PRIORITIZATION_RULES = "prioritization_rules"
 NODE_MAX_FILE_MODIFICATION_TIME_DIFF = "max_file_modification_time_diff"
 NODE_REMOVE_EMPTY_FOLDERS = "remove_empty_folders"
 NODE_DUPLICATES_TARGET_DIRECTORY = "duplicates_target_directory"
@@ -72,7 +74,7 @@ class DeduplicatorConfig(ConfigBase):
     )
 
     ELASTICSEARCH_HOST = StringConfigEntry(
-        description="Hostname of the elasticsearch backend instance to use",
+        description="Hostname of the elasticsearch backend instance to use.",
         key_path=[
             NODE_MAIN,
             NODE_ELASTICSEARCH,
@@ -82,7 +84,7 @@ class DeduplicatorConfig(ConfigBase):
     )
 
     ELASTICSEARCH_PORT = IntConfigEntry(
-        description="Hostname of the elasticsearch backend instance to use",
+        description="Port of the elasticsearch backend instance to use.",
         key_path=[
             NODE_MAIN,
             NODE_ELASTICSEARCH,
@@ -203,7 +205,7 @@ class DeduplicatorConfig(ConfigBase):
             NODE_ANALYSIS,
             NODE_THREADS
         ],
-        default=1
+        default=os.cpu_count()
     )
 
     MAX_FILE_MODIFICATION_TIME_DELTA = TimeDeltaConfigEntry(
@@ -216,6 +218,29 @@ class DeduplicatorConfig(ConfigBase):
         ],
         default=None,
         example=timedelta(minutes=5)
+    )
+
+    PRIORITIZATION_RULES = ListConfigEntry(
+        description="Comma separated list of prioritization rules to use for ordering duplicate "
+                    "images before proceeding with the deduplication process.",
+        item_type=StringConfigEntry,
+        key_path=[
+            NODE_MAIN,
+            NODE_DEDUPLICATION,
+            NODE_PRIORITIZATION_RULES
+        ],
+        required=False,
+        default=[
+            "higher-pixel-count",
+            "more-exif-data",
+            "bigger-file-size",
+            "newer-file-modification-date",
+            "smaller-distance",
+            "doesnt-contain-copy-in-file-name",
+            "longer-file-name",
+            "shorter-folder-path",
+            "higher-score",
+        ]
     )
 
     REMOVE_EMPTY_FOLDERS = BoolConfigEntry(

--- a/py_image_dedup_reference.yaml
+++ b/py_image_dedup_reference.yaml
@@ -1,31 +1,90 @@
+# This is a reference configuration file explaining all the options
+# of py-image-dedup.
+
 py_image_dedup:
+  # Configuration for the analysis phase, see README.md
   analysis:
+    # Whether to search for duplicates across directories when
+    # specifying more than one image source directory
     across_dirs: false
+    # A filter for the file extensions to analyse
     file_extensions:
       - .png
       - .jpg
       - .jpeg
+    # Whether to search recursively in each of the source directories
     recursive: true
+    # A list of source directories to analyse
     source_directories:
       - /home/myuser/pictures/
+    # A list of regex patterns to ignore when traversing any of the
+    # source directories
     exclusions:
       - ".*/excluded/.*"
+    # The number of threads to use for image analysis.
+    # If unset, this will default to `os.cpu_count()`.
     threads: 1
+    # Whether to include EXIF data of images in the analysis
     use_exif_data: true
+
+  # Deduplication phase specific configuration options, see README.md
   deduplication:
+    # The target directory to move duplicate images to
     duplicates_target_directory: /home/myuser/pictures/duplicates/
+    # Upper limit on the modification date difference between
+    # two duplicate images to be considered the same image.
     max_file_modification_time_diff: 0:05:00
+    # Specifies the criteria and their order for ordering the list of duplicates
+    # to select the best copy.
+    prioritization_rules:
+      - name: "more-exif-data"
+      - name: "less-exif-data"
+      - name: "bigger-file-size"
+      - name: "smaller-file-size"
+      - name: "newer-file-modification-date"
+      - name: "older-file-modification-date"
+      - name: "smaller-distance"
+      - name: "bigger-distance"
+      - name: "longer-path"
+      - name: "shorter-path"
+      - name: "contains-copy-in-file-name"
+      - name: "longer-file-name"
+      - name: "shorter-file-name"
+      - name: "longer-folder-path"
+      - name: "shorter-folder-path"
+      - name: "higher-score"
+      - name: "lower-score"
+
+  # Daemon specific configuration options, see README.md
   daemon:
+    # Time for waiting on filesystems changes to settle before analysing.
     timeout: 30s
+    # The type of file observer to use.
+    # One of: polling, inotify
     file_observer: polling
+  # A dry run can be used to validate the log output of a specific configuration
+  # before actually deleting or removing any images in any of the source
+  # directories.
   dry_run: true
+
+  # Elasticsearch specific configuration options, see README.md
   elasticsearch:
+    # Whether to automatically create an index in the target database.
     auto_create_index: true
+    # Hostname of the elasticsearch backend instance to use
     host: 127.0.0.1
+    # Port of the elasticsearch backend instance to use.
     port: 9200
+    # The index name to use for storing and querying image analysis data.
     index: images
+    # Maximum signature distance [0..1] to query from elasticsearch backend.
     max_distance: 0.1
+  # Whether to remove empty folders or not.
   remove_empty_folders: false
+
+  # Prometheus exporter specific configuration options, see README.md
   stats:
+    # Whether to enable prometheus statistics or not.
     enabled: true
+    # The port to expose statistics on.
     port: 8000

--- a/tests/py_image_dedup.yaml
+++ b/tests/py_image_dedup.yaml
@@ -14,8 +14,28 @@ py_image_dedup:
   deduplication:
     # duplicates_target_directory:
     max_file_modification_time_diff: 0:01:40
+    prioritization_rules:
+      - name: "more-exif-data"
+      - name: "less-exif-data"
+      - name: "bigger-file-size"
+      - name: "smaller-file-size"
+      - name: "newer-file-modification-date"
+      - name: "older-file-modification-date"
+      - name: "smaller-distance"
+      - name: "bigger-distance"
+      - name: "longer-path"
+      - name: "shorter-path"
+      - name: "contains-copy-in-file-name"
+      - name: "longer-file-name"
+      - name: "shorter-file-name"
+      - name: "longer-folder-path"
+      - name: "shorter-folder-path"
+      - name: "higher-score"
+      - name: "lower-score"
+
   elasticsearch:
     auto_create_index: true
     host: 127.0.0.1
     max_distance: 0.1
   remove_empty_folders: false
+


### PR DESCRIPTION
fixes #80

Adds a configuration option to set a custom list of prioritization rules:
```
  deduplication:
    prioritization_rules:
      - name: "higher-pixel-count"
      - name: "lower-pixel-count"
      - name: "more-exif-data"
      - name: "less-exif-data"
      - name: "bigger-file-size"
      - name: "smaller-file-size"
      - name: "newer-file-modification-date"
      - name: "older-file-modification-date"
      - name: "smaller-distance"
      - name: "bigger-distance"
      - name: "longer-path"
      - name: "shorter-path"
      - name: "contains-copy-in-file-name"
      - name: "longer-file-name"
      - name: "shorter-file-name"
      - name: "longer-folder-path"
      - name: "shorter-folder-path"
      - name: "higher-score"
      - name: "lower-score"
```

